### PR TITLE
feat: add auto lookback mode

### DIFF
--- a/crates/claude-chill/src/bin.rs
+++ b/crates/claude-chill/src/bin.rs
@@ -18,6 +18,10 @@ fn main() -> ExitCode {
         .clone()
         .unwrap_or_else(|| config.lookback_key.clone());
 
+    let auto_lookback_timeout_ms = cli
+        .auto_lookback_timeout
+        .unwrap_or(config.auto_lookback_timeout_ms);
+
     let lookback_sequence = match key_parser::parse(&lookback_key) {
         Ok(key) => key.to_escape_sequence(),
         Err(e) => {
@@ -32,6 +36,7 @@ fn main() -> ExitCode {
         max_history_lines: history_lines,
         lookback_key,
         lookback_sequence,
+        auto_lookback_timeout_ms,
     };
 
     let cmd_args: Vec<&str> = cli.args.iter().map(|s| s.as_str()).collect();

--- a/crates/claude-chill/src/cli.rs
+++ b/crates/claude-chill/src/cli.rs
@@ -17,7 +17,8 @@ use clap::Parser;
                   Create ~/.config/claude-chill.toml:\n\n    \
                   max_lines = 100        # Lines shown per sync block\n    \
                   history_lines = 100000 # Lines stored for lookback\n    \
-                  lookback_key = \"[ctrl][shift][j]\"\n\n\
+                  lookback_key = \"[ctrl][shift][j]\"\n    \
+                  auto_lookback_timeout_ms = 1000  # Auto lookback after idle (ms)\n\n\
                   KEY FORMAT: [modifier][key]\n    \
                   Modifiers: [ctrl], [shift], [alt]\n    \
                   Keys: [a]-[z], [f1]-[f12], [pageup], [enter], [space], etc."
@@ -56,4 +57,11 @@ pub struct Cli {
         value_name = "KEY"
     )]
     pub lookback_key: Option<String>,
+
+    #[arg(
+        long = "auto-lookback-timeout",
+        help = "Auto lookback timeout in milliseconds (0 to disable)",
+        value_name = "MILLISECONDS"
+    )]
+    pub auto_lookback_timeout: Option<u64>,
 }

--- a/crates/claude-chill/src/config.rs
+++ b/crates/claude-chill/src/config.rs
@@ -11,6 +11,7 @@ pub struct Config {
     pub max_lines: usize,
     pub history_lines: usize,
     pub lookback_key: String,
+    pub auto_lookback_timeout_ms: u64,
 }
 
 impl Default for Config {
@@ -19,6 +20,7 @@ impl Default for Config {
             max_lines: 100,
             history_lines: 100_000,
             lookback_key: DEFAULT_LOOKBACK_KEY.to_string(),
+            auto_lookback_timeout_ms: 1000,
         }
     }
 }
@@ -90,6 +92,7 @@ mod tests {
         assert_eq!(config.max_lines, 100);
         assert_eq!(config.history_lines, 100_000);
         assert_eq!(config.lookback_key, "[ctrl][6]");
+        assert_eq!(config.auto_lookback_timeout_ms, 1000);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Automatically shows full terminal history after 1 second of idle
- Returns to truncated view when new output arrives
- Configurable via `auto_lookback_timeout_ms` in config or `--auto-lookback-timeout` CLI flag
- Set to 0 to disable

## Test plan
- [ ] Run command with long output, wait 1s after completion → full history appears
- [ ] Start new command → switches back to truncated view
- [ ] Set timeout to 0 → feature disabled
- [ ] Manual lookback (Ctrl+6) still works independently