### PR TITLE
docs: update README for auto-lookback feature and add -a short flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Options:
   -H, --history <HISTORY_LINES>
           Max lines stored for lookback (default: 100000)
   -k, --lookback-key <LOOKBACK_KEY>
-          Key to toggle lookback mode (default: "[ctrl][6]")
+          Key to toggle lookback mode, quote to prevent glob expansion (default: "[ctrl][6]")
   -a, --auto-lookback-timeout <AUTO_LOOKBACK_TIMEOUT>
           Auto-lookback timeout in ms, 0 to disable (default: 5000)
   -h, --help

--- a/crates/claude-chill/src/cli.rs
+++ b/crates/claude-chill/src/cli.rs
@@ -18,7 +18,7 @@ pub struct Cli {
     #[arg(short = 'H', long = "history")]
     pub history_lines: Option<usize>,
 
-    /// Key to toggle lookback mode (default: "[ctrl][6]")
+    /// Key to toggle lookback mode, quote to prevent glob expansion (default: "[ctrl][6]")
     #[arg(short = 'k', long = "lookback-key")]
     pub lookback_key: Option<String>,
 


### PR DESCRIPTION
- Add -a short flag for --auto-lookback-timeout CLI argument
- Add CLI help output to README with descriptions
- Add usage examples including how to pass args to claude
- Document auto-lookback feature with its own section
- Explain flicker behavior and how to disable it
- Show configuration via command line and config file
- Update config file example with all available options