### PR TITLE
Add cargo install --git to installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ claude-chill sits between your terminal and Claude Code:
 ## Installation
 
 ```bash
+cargo install --git https://github.com/davidbeesley/claude-chill
+```
+
+Or, if you've cloned the repository locally:
+
+```bash
 cargo install --path crates/claude-chill
 ```
 


### PR DESCRIPTION
## Problem

The installation section only shows:

```bash
cargo install --path crates/claude-chill
```

This requires cloning the repo first, but that step is never mentioned. Users who just want to install the tool copy-paste the command and get a confusing error:

```
error: `/path/crates/claude-chill` is not a directory.
--path must point to a directory containing a Cargo.toml file.
```

`cargo install --path` is a local-build command — it expects a directory with a `Cargo.toml` on disk. Without prior context of how Cargo works, the error message doesn't make it obvious that you need to clone first.

## Solution

Add `cargo install --git` as the primary installation method since it handles cloning, building, and installing in one step — no local checkout needed. The existing `--path` method is kept below with a note that it requires a local clone.