### PR TITLE
feat: add Windows support via platform abstraction

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,10 @@ jobs:
 
   check:
     name: Check
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -58,7 +61,7 @@ jobs:
   test-matrix:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,74 @@
+name: Release
+
+on:
+  release:
+    types: [created]
+
+permissions:
+  contents: write
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    name: Build ${{ matrix.target }}
+    strategy:
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+            artifact: claude-chill
+            archive: claude-chill-linux-x86_64.tar.gz
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+            artifact: claude-chill
+            archive: claude-chill-linux-aarch64.tar.gz
+          - target: x86_64-apple-darwin
+            os: macos-latest
+            artifact: claude-chill
+            archive: claude-chill-macos-x86_64.tar.gz
+          - target: aarch64-apple-darwin
+            os: macos-latest
+            artifact: claude-chill
+            archive: claude-chill-macos-aarch64.tar.gz
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+            artifact: claude-chill.exe
+            archive: claude-chill-windows-x86_64.zip
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Install cross-compilation tools (Linux aarch64)
+        if: matrix.target == 'aarch64-unknown-linux-gnu'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu
+          echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
+
+      - name: Build
+        run: cargo build --release --target ${{ matrix.target }}
+
+      - name: Package (Unix)
+        if: runner.os != 'Windows'
+        run: |
+          cd target/${{ matrix.target }}/release
+          tar czf ../../../${{ matrix.archive }} ${{ matrix.artifact }}
+
+      - name: Package (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          Compress-Archive -Path "target/${{ matrix.target }}/release/${{ matrix.artifact }}" -DestinationPath "${{ matrix.archive }}"
+
+      - name: Upload to Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release upload ${{ github.event.release.tag_name }} ${{ matrix.archive }} --clobber

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ![Version](https://img.shields.io/badge/version-0.1.4-blue)
 ![Linux](https://img.shields.io/badge/Linux-supported-green)
 ![macOS](https://img.shields.io/badge/macOS-supported-green)
-![Windows](https://img.shields.io/badge/Windows-unsupported-red)
+![Windows](https://img.shields.io/badge/Windows-supported-green)
 ![Rust](https://img.shields.io/badge/rust-2024-orange)
 
 A PTY proxy that tames Claude Code's massive terminal updates using VT-based rendering.
@@ -26,6 +26,22 @@ claude-chill sits between your terminal and Claude Code:
 4. **Enables lookback** - Press a key to pause Claude and view the full history buffer
 
 ## Installation
+
+### Pre-built Binaries
+
+Download the latest release for your platform from [GitHub Releases](https://github.com/davidbeesley/claude-chill/releases):
+
+| Platform | Download |
+|----------|----------|
+| Linux (x86_64) | `claude-chill-linux-x86_64.tar.gz` |
+| Linux (aarch64) | `claude-chill-linux-aarch64.tar.gz` |
+| macOS (Intel) | `claude-chill-macos-x86_64.tar.gz` |
+| macOS (Apple Silicon) | `claude-chill-macos-aarch64.tar.gz` |
+| Windows (x86_64) | `claude-chill-windows-x86_64.zip` |
+
+Extract and place the binary in your PATH.
+
+### From Source (requires Rust)
 
 ```bash
 cargo install --git https://github.com/davidbeesley/claude-chill
@@ -115,6 +131,7 @@ After `auto_lookback_timeout_ms` (default 15 seconds) of idle (no user input), t
 Config file location:
 - **Linux**: `~/.config/claude-chill.toml`
 - **macOS**: `~/Library/Application Support/claude-chill.toml`
+- **Windows**: `%APPDATA%\claude-chill.toml`
 
 ```toml
 history_lines = 100000           # Max lines stored for lookback
@@ -149,7 +166,7 @@ Keys: `[a]`-`[z]`, `[f1]`-`[f12]`, `[pageup]`, `[pagedown]`, `[home]`, `[end]`, 
 
 ## How It Works
 
-claude-chill creates a pseudo-terminal (PTY) and spawns Claude Code as a child process. It then acts as a transparent proxy between your terminal and Claude:
+claude-chill creates a pseudo-terminal (PTY on Unix, ConPTY on Windows) and spawns Claude Code as a child process. It then acts as a transparent proxy between your terminal and Claude:
 
 ```
 ┌──────────────┐     ┌──────────────┐     ┌──────────────┐
@@ -164,7 +181,7 @@ claude-chill creates a pseudo-terminal (PTY) and spawns Claude Code as a child p
 3. **VT emulation**: Feeds output through a VT100 emulator to track the virtual screen state
 4. **Differential rendering**: Compares current screen to previous and emits only the changes
 5. **History tracking**: Maintains a buffer of output for lookback mode since the last full redraw
-6. **Signal forwarding**: Window resize (SIGWINCH), interrupt (SIGINT), and terminate (SIGTERM) signals are forwarded to Claude
+6. **Signal forwarding**: Window resize, interrupt, and terminate signals are forwarded to Claude (SIGWINCH/SIGINT/SIGTERM on Unix, console events on Windows)
 
 ## Installation with Nix
 

--- a/crates/claude-chill/Cargo.toml
+++ b/crates/claude-chill/Cargo.toml
@@ -21,11 +21,26 @@ anyhow = "1"
 clap = { version = "4", features = ["derive"] }
 dirs = "6"
 memchr = "2"
-nix = { version = "0.30", features = ["term", "signal", "poll", "process", "fs"] }
-libc = "0.2"
 serde = { version = "1", features = ["derive"] }
 toml = "0.8"
 vt100 = "0.16"
 termwiz = "0.23"
 log = "0.4"
 env_logger = "0.11"
+
+# Unix-specific dependencies
+[target.'cfg(unix)'.dependencies]
+nix = { version = "0.30", features = ["term", "signal", "poll", "process", "fs"] }
+libc = "0.2"
+
+# Windows-specific dependencies
+[target.'cfg(windows)'.dependencies]
+windows = { version = "0.58", features = [
+    "Win32_Foundation",
+    "Win32_Storage_FileSystem",
+    "Win32_System_Console",
+    "Win32_System_IO",
+    "Win32_System_Pipes",
+    "Win32_System_Threading",
+    "Win32_Security",
+]}

--- a/crates/claude-chill/src/lib.rs
+++ b/crates/claude-chill/src/lib.rs
@@ -4,5 +4,6 @@ pub mod escape_sequences;
 pub mod history_filter;
 pub mod key_parser;
 pub mod line_buffer;
+pub mod platform;
 pub mod proxy;
 pub mod redraw_throttler;

--- a/crates/claude-chill/src/platform/mod.rs
+++ b/crates/claude-chill/src/platform/mod.rs
@@ -1,0 +1,155 @@
+//! Platform abstraction layer for cross-platform terminal/PTY support.
+//!
+//! This module provides a common interface for platform-specific functionality:
+//! - Unix (Linux, macOS): Uses POSIX PTY, termios, signals
+//! - Windows: Uses Windows Pseudoconsole API, Console API, console events
+
+use anyhow::Result;
+use std::io;
+
+#[cfg(unix)]
+mod unix;
+#[cfg(unix)]
+pub use unix::*;
+
+#[cfg(windows)]
+mod windows;
+#[cfg(windows)]
+pub use windows::*;
+
+/// Terminal size in rows and columns
+#[derive(Debug, Clone, Copy)]
+pub struct TerminalSize {
+    pub rows: u16,
+    pub cols: u16,
+}
+
+impl Default for TerminalSize {
+    fn default() -> Self {
+        Self { rows: 24, cols: 80 }
+    }
+}
+
+/// Platform-specific signal types that we handle
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PlatformSignal {
+    /// Window resize (SIGWINCH on Unix, console event on Windows)
+    Resize,
+    /// Interrupt (SIGINT on Unix, CTRL_C_EVENT on Windows)
+    Interrupt,
+    /// Terminate (SIGTERM on Unix, CTRL_BREAK_EVENT on Windows)
+    Terminate,
+}
+
+/// Result of polling for I/O events
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PollResult {
+    /// PTY has data ready to read
+    PtyReadable,
+    /// Stdin has data ready to read
+    StdinReadable,
+    /// Both PTY and stdin have data ready
+    BothReadable,
+    /// Timeout with no events
+    Timeout,
+    /// Poll was interrupted (e.g., by signal)
+    Interrupted,
+    /// PTY closed/hung up
+    PtyHangup,
+}
+
+/// Check if stdin is a TTY
+pub fn is_tty() -> bool {
+    #[cfg(unix)]
+    {
+        unix::is_stdin_tty()
+    }
+    #[cfg(windows)]
+    {
+        windows::is_stdin_tty()
+    }
+}
+
+/// Get the current terminal size
+pub fn get_terminal_size() -> Result<TerminalSize> {
+    #[cfg(unix)]
+    {
+        unix::get_terminal_size()
+    }
+    #[cfg(windows)]
+    {
+        windows::get_terminal_size()
+    }
+}
+
+/// Write data to stdout
+pub fn write_stdout(data: &[u8]) -> Result<()> {
+    #[cfg(unix)]
+    {
+        unix::write_stdout(data)
+    }
+    #[cfg(windows)]
+    {
+        windows::write_stdout(data)
+    }
+}
+
+/// Read from stdin (non-blocking where possible)
+pub fn read_stdin(buf: &mut [u8]) -> io::Result<usize> {
+    #[cfg(unix)]
+    {
+        unix::read_stdin(buf)
+    }
+    #[cfg(windows)]
+    {
+        windows::read_stdin(buf)
+    }
+}
+
+/// Setup platform signal handlers
+pub fn setup_signal_handlers() -> Result<()> {
+    #[cfg(unix)]
+    {
+        unix::setup_signal_handlers()
+    }
+    #[cfg(windows)]
+    {
+        windows::setup_signal_handlers()
+    }
+}
+
+/// Check and clear pending signals
+pub fn check_signals() -> Vec<PlatformSignal> {
+    #[cfg(unix)]
+    {
+        unix::check_signals()
+    }
+    #[cfg(windows)]
+    {
+        windows::check_signals()
+    }
+}
+
+/// Restore terminal to original state
+pub fn restore_terminal(state: &OriginalTerminalState) {
+    #[cfg(unix)]
+    {
+        unix::restore_terminal(state)
+    }
+    #[cfg(windows)]
+    {
+        windows::restore_terminal(state)
+    }
+}
+
+/// Poll stdin for input with a timeout (used for Kitty detection)
+pub fn poll_stdin(timeout_ms: u16) -> Result<bool> {
+    #[cfg(unix)]
+    {
+        unix::poll_stdin(timeout_ms)
+    }
+    #[cfg(windows)]
+    {
+        windows::poll_stdin(timeout_ms)
+    }
+}

--- a/crates/claude-chill/src/platform/unix.rs
+++ b/crates/claude-chill/src/platform/unix.rs
@@ -1,0 +1,414 @@
+//! Unix (Linux, macOS) platform implementation.
+//!
+//! Uses POSIX PTY, termios, signals, and poll() for I/O multiplexing.
+
+use super::{PlatformSignal, PollResult, TerminalSize};
+use anyhow::{Context, Result};
+use nix::errno::Errno;
+use nix::fcntl::{FcntlArg, OFlag, fcntl};
+use nix::poll::{PollFd, PollFlags, PollTimeout, poll};
+use nix::pty::{Winsize, openpty};
+use nix::sys::signal::{SaFlags, SigAction, SigHandler, SigSet, Signal, kill, sigaction};
+use nix::sys::termios::{SetArg, Termios, cfmakeraw, tcgetattr, tcsetattr};
+use nix::unistd::{Pid, isatty, read, write};
+use std::io;
+use std::os::fd::{AsFd, AsRawFd, BorrowedFd, OwnedFd};
+use std::os::unix::process::CommandExt;
+use std::process::{Child, Command, ExitStatus};
+use std::sync::atomic::{AtomicBool, Ordering};
+
+// Signal flags - set by signal handlers, checked in main loop
+static SIGWINCH_RECEIVED: AtomicBool = AtomicBool::new(false);
+static SIGINT_RECEIVED: AtomicBool = AtomicBool::new(false);
+static SIGTERM_RECEIVED: AtomicBool = AtomicBool::new(false);
+
+extern "C" fn handle_sigwinch(_: libc::c_int) {
+    SIGWINCH_RECEIVED.store(true, Ordering::SeqCst);
+}
+
+extern "C" fn handle_sigint(_: libc::c_int) {
+    SIGINT_RECEIVED.store(true, Ordering::SeqCst);
+}
+
+extern "C" fn handle_sigterm(_: libc::c_int) {
+    SIGTERM_RECEIVED.store(true, Ordering::SeqCst);
+}
+
+/// Original termios for restoration
+pub type OriginalTerminalState = Termios;
+
+/// Unix PTY wrapper
+pub struct Pty {
+    pub master: OwnedFd,
+    child: Child,
+}
+
+impl Pty {
+    /// Spawn a child process in a new PTY
+    pub fn spawn(command: &str, args: &[&str], size: TerminalSize) -> Result<Self> {
+        let winsize = Winsize {
+            ws_row: size.rows,
+            ws_col: size.cols,
+            ws_xpixel: 0,
+            ws_ypixel: 0,
+        };
+
+        let pty = openpty(&winsize, None).context("openpty failed")?;
+        let slave_fd = pty.slave.as_raw_fd();
+
+        let child = unsafe {
+            Command::new(command)
+                .args(args)
+                .pre_exec(move || {
+                    if libc::setsid() == -1 {
+                        return Err(io::Error::last_os_error());
+                    }
+                    if libc::ioctl(slave_fd, libc::TIOCSCTTY as libc::c_ulong, 0) == -1 {
+                        return Err(io::Error::last_os_error());
+                    }
+                    if libc::dup2(slave_fd, 0) == -1 {
+                        return Err(io::Error::last_os_error());
+                    }
+                    if libc::dup2(slave_fd, 1) == -1 {
+                        return Err(io::Error::last_os_error());
+                    }
+                    if libc::dup2(slave_fd, 2) == -1 {
+                        return Err(io::Error::last_os_error());
+                    }
+                    if slave_fd > 2 {
+                        libc::close(slave_fd);
+                    }
+                    Ok(())
+                })
+                .spawn()
+                .context("spawn failed")?
+        };
+
+        // Close slave in parent - child has its own copy
+        drop(pty.slave);
+
+        // Set master to non-blocking
+        set_nonblocking(&pty.master)?;
+
+        Ok(Self {
+            master: pty.master,
+            child,
+        })
+    }
+
+    /// Read from PTY master. Returns Ok(0) on EOF, Err on error.
+    pub fn read(&self, buf: &mut [u8]) -> Result<usize, PtyReadError> {
+        match read(self.master.as_fd(), buf) {
+            Ok(n) => Ok(n),
+            Err(Errno::EAGAIN) => Err(PtyReadError::WouldBlock),
+            Err(Errno::EIO) => Err(PtyReadError::Eof),
+            Err(e) => Err(PtyReadError::Other(format!("read from pty failed: {}", e))),
+        }
+    }
+
+    /// Write to PTY master
+    pub fn write(&self, data: &[u8]) -> Result<()> {
+        write_all_fd(&self.master, data)
+    }
+
+    /// Write to PTY master, draining child output when buffer is full.
+    /// This prevents the classic pty deadlock where both sides block on full buffers.
+    pub fn write_draining(&self, data: &[u8], drain_buffer: &mut Vec<u8>) -> Result<()> {
+        let mut written = 0;
+        let mut read_buf = [0u8; 65536];
+
+        while written < data.len() {
+            match write(&self.master, &data[written..]) {
+                Ok(n) => written += n,
+                Err(Errno::EAGAIN) => {
+                    // PTY buffer full - drain child output to make room
+                    match read(self.master.as_fd(), &mut read_buf) {
+                        Ok(n) if n > 0 => {
+                            drain_buffer.extend_from_slice(&read_buf[..n]);
+                        }
+                        _ => {
+                            // Nothing available yet, poll briefly
+                            let mut poll_fds = [PollFd::new(
+                                self.master.as_fd(),
+                                PollFlags::POLLIN | PollFlags::POLLOUT,
+                            )];
+                            let _ = poll(&mut poll_fds, PollTimeout::from(10u16));
+                        }
+                    }
+                }
+                Err(Errno::EINTR) => continue,
+                Err(e) => anyhow::bail!("write to pty failed: {}", e),
+            }
+        }
+        Ok(())
+    }
+
+    /// Set the PTY window size
+    pub fn set_size(&self, size: TerminalSize) -> Result<()> {
+        let winsize = Winsize {
+            ws_row: size.rows,
+            ws_col: size.cols,
+            ws_xpixel: 0,
+            ws_ypixel: 0,
+        };
+        unsafe {
+            libc::ioctl(
+                self.master.as_raw_fd(),
+                libc::TIOCSWINSZ as libc::c_ulong,
+                &winsize,
+            );
+        }
+        Ok(())
+    }
+
+    /// Get the child process ID
+    pub fn child_pid(&self) -> u32 {
+        self.child.id()
+    }
+
+    /// Send a signal to the child process
+    pub fn signal(&self, sig: PlatformSignal) {
+        let signal = match sig {
+            PlatformSignal::Interrupt => Signal::SIGINT,
+            PlatformSignal::Terminate => Signal::SIGTERM,
+            PlatformSignal::Resize => return,
+        };
+        let pid = Pid::from_raw(self.child.id() as i32);
+        let _ = kill(pid, signal);
+    }
+
+    /// Wait for child to exit
+    pub fn wait(&mut self) -> Result<i32> {
+        match self.child.wait() {
+            Ok(status) => Ok(exit_code_from_status(status)),
+            Err(e) => anyhow::bail!("wait failed: {}", e),
+        }
+    }
+}
+
+/// PTY read error types (platform-independent)
+#[derive(Debug)]
+pub enum PtyReadError {
+    WouldBlock,
+    Eof,
+    Other(String),
+}
+
+impl std::fmt::Display for PtyReadError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PtyReadError::WouldBlock => write!(f, "would block"),
+            PtyReadError::Eof => write!(f, "eof"),
+            PtyReadError::Other(msg) => write!(f, "{}", msg),
+        }
+    }
+}
+
+impl std::error::Error for PtyReadError {}
+
+/// Terminal raw mode guard - restores original mode on drop
+pub struct RawModeGuard {
+    original_termios: Option<Termios>,
+}
+
+impl RawModeGuard {
+    /// Enable raw mode and return guard that restores on drop
+    pub fn new() -> Result<Self> {
+        let original_termios = setup_raw_mode()?;
+        Ok(Self { original_termios })
+    }
+
+    /// Take ownership of the original termios (for manual restoration)
+    pub fn take(mut self) -> Option<Termios> {
+        self.original_termios.take()
+    }
+}
+
+impl Drop for RawModeGuard {
+    fn drop(&mut self) {
+        if let Some(ref termios) = self.original_termios {
+            let _ = tcsetattr(io::stdin(), SetArg::TCSANOW, termios);
+        }
+    }
+}
+
+/// Restore terminal from raw mode
+pub fn restore_terminal(termios: &Termios) {
+    let _ = tcsetattr(io::stdin(), SetArg::TCSANOW, termios);
+}
+
+/// Check if stdin is a TTY
+pub fn is_stdin_tty() -> bool {
+    isatty(io::stdin().as_fd()).unwrap_or(false)
+}
+
+/// Get the current terminal size
+pub fn get_terminal_size() -> Result<TerminalSize> {
+    let mut ws: Winsize = unsafe { std::mem::zeroed() };
+    let ret = unsafe {
+        libc::ioctl(
+            io::stdout().as_raw_fd(),
+            libc::TIOCGWINSZ as libc::c_ulong,
+            &mut ws,
+        )
+    };
+    if ret == -1 || ws.ws_row == 0 || ws.ws_col == 0 {
+        Ok(TerminalSize::default())
+    } else {
+        Ok(TerminalSize {
+            rows: ws.ws_row,
+            cols: ws.ws_col,
+        })
+    }
+}
+
+/// Setup signal handlers for SIGWINCH, SIGINT, SIGTERM
+pub fn setup_signal_handlers() -> Result<()> {
+    setup_signal_handler(Signal::SIGWINCH, handle_sigwinch)?;
+    setup_signal_handler(Signal::SIGINT, handle_sigint)?;
+    setup_signal_handler(Signal::SIGTERM, handle_sigterm)?;
+    Ok(())
+}
+
+/// Check and clear pending signals, returning which ones fired
+pub fn check_signals() -> Vec<PlatformSignal> {
+    let mut signals = Vec::new();
+    if SIGWINCH_RECEIVED.swap(false, Ordering::SeqCst) {
+        signals.push(PlatformSignal::Resize);
+    }
+    if SIGINT_RECEIVED.swap(false, Ordering::SeqCst) {
+        signals.push(PlatformSignal::Interrupt);
+    }
+    if SIGTERM_RECEIVED.swap(false, Ordering::SeqCst) {
+        signals.push(PlatformSignal::Terminate);
+    }
+    signals
+}
+
+/// Poll for I/O events on PTY and stdin
+pub fn poll_io(pty: &Pty, timeout_ms: u16) -> Result<PollResult> {
+    let master_fd = pty.master.as_fd();
+    let stdin_fd = io::stdin();
+    let stdin_borrowed = unsafe { BorrowedFd::borrow_raw(stdin_fd.as_raw_fd()) };
+
+    let mut poll_fds = [
+        PollFd::new(master_fd, PollFlags::POLLIN),
+        PollFd::new(stdin_borrowed, PollFlags::POLLIN),
+    ];
+
+    match poll(&mut poll_fds, PollTimeout::from(timeout_ms)) {
+        Ok(0) => Ok(PollResult::Timeout),
+        Ok(_) => {
+            let pty_readable = poll_fds[0]
+                .revents()
+                .map(|r| r.contains(PollFlags::POLLIN))
+                .unwrap_or(false);
+            let pty_hangup = poll_fds[0]
+                .revents()
+                .map(|r| r.contains(PollFlags::POLLHUP))
+                .unwrap_or(false);
+            let stdin_readable = poll_fds[1]
+                .revents()
+                .map(|r| r.contains(PollFlags::POLLIN))
+                .unwrap_or(false);
+
+            if pty_hangup && !pty_readable {
+                Ok(PollResult::PtyHangup)
+            } else if pty_readable && stdin_readable {
+                Ok(PollResult::BothReadable)
+            } else if pty_readable {
+                Ok(PollResult::PtyReadable)
+            } else if stdin_readable {
+                Ok(PollResult::StdinReadable)
+            } else if pty_hangup {
+                Ok(PollResult::PtyHangup)
+            } else {
+                Ok(PollResult::Timeout)
+            }
+        }
+        Err(Errno::EINTR) => Ok(PollResult::Interrupted),
+        Err(e) => anyhow::bail!("poll failed: {}", e),
+    }
+}
+
+/// Poll stdin for input with a timeout (used for Kitty detection)
+pub fn poll_stdin(timeout_ms: u16) -> Result<bool> {
+    let stdin = io::stdin();
+    let mut poll_fd = [PollFd::new(stdin.as_fd(), PollFlags::POLLIN)];
+    match poll(&mut poll_fd, PollTimeout::from(timeout_ms)) {
+        Ok(0) => Ok(false),
+        Ok(_) => Ok(true),
+        Err(Errno::EINTR) => Ok(false),
+        Err(e) => anyhow::bail!("poll stdin failed: {}", e),
+    }
+}
+
+/// Read from stdin (non-blocking)
+pub fn read_stdin(buf: &mut [u8]) -> io::Result<usize> {
+    match read(io::stdin().as_fd(), buf) {
+        Ok(n) => Ok(n),
+        Err(Errno::EAGAIN) => Ok(0),
+        Err(e) => Err(io::Error::from_raw_os_error(e as i32)),
+    }
+}
+
+/// Write data to stdout
+pub fn write_stdout(data: &[u8]) -> Result<()> {
+    write_all_fd(&io::stdout(), data)
+}
+
+// ============ Internal helpers ============
+
+fn setup_raw_mode() -> Result<Option<Termios>> {
+    let stdin = io::stdin();
+    if !isatty(&stdin).unwrap_or(false) {
+        return Ok(None);
+    }
+
+    let original = tcgetattr(&stdin).context("tcgetattr failed")?;
+    let mut raw = original.clone();
+    cfmakeraw(&mut raw);
+    tcsetattr(&stdin, SetArg::TCSANOW, &raw).context("tcsetattr failed")?;
+    Ok(Some(original))
+}
+
+fn setup_signal_handler(signal: Signal, handler: extern "C" fn(libc::c_int)) -> Result<()> {
+    let action = SigAction::new(
+        SigHandler::Handler(handler),
+        SaFlags::SA_RESTART,
+        SigSet::empty(),
+    );
+    unsafe { sigaction(signal, &action) }.context(format!("sigaction {:?} failed", signal))?;
+    Ok(())
+}
+
+fn set_nonblocking<Fd: AsFd>(fd: &Fd) -> Result<()> {
+    let flags = fcntl(fd.as_fd(), FcntlArg::F_GETFL).context("fcntl F_GETFL failed")?;
+    let flags = OFlag::from_bits_truncate(flags);
+    fcntl(fd.as_fd(), FcntlArg::F_SETFL(flags | OFlag::O_NONBLOCK))
+        .context("fcntl F_SETFL failed")?;
+    Ok(())
+}
+
+fn write_all_fd<F: AsFd>(fd: &F, data: &[u8]) -> Result<()> {
+    let mut written = 0;
+    while written < data.len() {
+        match write(fd, &data[written..]) {
+            Ok(n) => written += n,
+            Err(Errno::EAGAIN) | Err(Errno::EINTR) => continue,
+            Err(e) => anyhow::bail!("write failed: {}", e),
+        }
+    }
+    Ok(())
+}
+
+fn exit_code_from_status(status: ExitStatus) -> i32 {
+    use std::os::unix::process::ExitStatusExt;
+    if let Some(code) = status.code() {
+        code
+    } else if let Some(signal) = status.signal() {
+        128 + signal
+    } else {
+        1
+    }
+}

--- a/crates/claude-chill/src/platform/windows.rs
+++ b/crates/claude-chill/src/platform/windows.rs
@@ -1,0 +1,523 @@
+//! Windows platform implementation.
+//!
+//! Uses Windows Pseudoconsole (ConPTY) API, Console API, and console events.
+//! Requires Windows 10 version 1809 or later.
+
+use super::{PlatformSignal, PollResult, TerminalSize};
+use anyhow::{Context, Result};
+use std::io::{self, Read, Write};
+use std::ptr;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use windows::Win32::Foundation::{
+    CloseHandle, BOOL, FALSE, HANDLE, INVALID_HANDLE_VALUE, TRUE, WAIT_FAILED, WAIT_OBJECT_0,
+    WAIT_TIMEOUT,
+};
+use windows::Win32::Storage::FileSystem::{ReadFile, WriteFile};
+use windows::Win32::System::Console::{
+    ClosePseudoConsole, CreatePseudoConsole, GetConsoleMode, GetConsoleScreenBufferInfo,
+    GetNumberOfConsoleInputEvents, GetStdHandle, ResizePseudoConsole, SetConsoleCtrlHandler,
+    SetConsoleMode, CONSOLE_MODE, CONSOLE_SCREEN_BUFFER_INFO, COORD, ENABLE_ECHO_INPUT,
+    ENABLE_LINE_INPUT, ENABLE_PROCESSED_INPUT, ENABLE_VIRTUAL_TERMINAL_INPUT,
+    ENABLE_VIRTUAL_TERMINAL_PROCESSING, HPCON, STD_INPUT_HANDLE, STD_OUTPUT_HANDLE,
+};
+use windows::Win32::System::Pipes::CreatePipe;
+use windows::Win32::System::Threading::{
+    CreateProcessW, GetExitCodeProcess, InitializeProcThreadAttributeList,
+    UpdateProcThreadAttribute, WaitForMultipleObjects, WaitForSingleObject,
+    EXTENDED_STARTUPINFO_PRESENT, LPPROC_THREAD_ATTRIBUTE_LIST, PROCESS_INFORMATION,
+    PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE, STARTUPINFOEXW,
+};
+
+// Signal flags - set by console control handler, checked in main loop
+static CTRL_C_RECEIVED: AtomicBool = AtomicBool::new(false);
+static CTRL_BREAK_RECEIVED: AtomicBool = AtomicBool::new(false);
+
+/// Original console mode for restoration
+#[derive(Clone)]
+pub struct OriginalTerminalState {
+    stdin_mode: CONSOLE_MODE,
+    stdout_mode: CONSOLE_MODE,
+}
+
+/// PTY read error types (platform-independent)
+#[derive(Debug)]
+pub enum PtyReadError {
+    WouldBlock,
+    Eof,
+    Other(String),
+}
+
+impl std::fmt::Display for PtyReadError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PtyReadError::WouldBlock => write!(f, "would block"),
+            PtyReadError::Eof => write!(f, "eof"),
+            PtyReadError::Other(msg) => write!(f, "{}", msg),
+        }
+    }
+}
+
+impl std::error::Error for PtyReadError {}
+
+/// Windows Pseudoconsole (ConPTY) wrapper
+pub struct Pty {
+    hpc: HPCON,
+    pipe_in: HANDLE,  // Write to this to send input to child
+    pipe_out: HANDLE, // Read from this to get output from child
+    process: HANDLE,
+    thread: HANDLE,
+    child_pid: u32,
+}
+
+impl Pty {
+    /// Spawn a child process in a new Pseudoconsole
+    pub fn spawn(command: &str, args: &[&str], size: TerminalSize) -> Result<Self> {
+        unsafe {
+            // Create pipes for PTY I/O
+            let mut pipe_pty_in = INVALID_HANDLE_VALUE;
+            let mut pipe_to_pty = INVALID_HANDLE_VALUE;
+            let mut pipe_from_pty = INVALID_HANDLE_VALUE;
+            let mut pipe_pty_out = INVALID_HANDLE_VALUE;
+
+            // Input pipe: we write to pipe_to_pty, PTY reads from pipe_pty_in
+            CreatePipe(&mut pipe_pty_in, &mut pipe_to_pty, None, 0)
+                .context("CreatePipe for input failed")?;
+
+            // Output pipe: PTY writes to pipe_pty_out, we read from pipe_from_pty
+            CreatePipe(&mut pipe_from_pty, &mut pipe_pty_out, None, 0)
+                .context("CreatePipe for output failed")?;
+
+            // Create the Pseudoconsole
+            let coord = COORD {
+                X: size.cols as i16,
+                Y: size.rows as i16,
+            };
+            let hpc = CreatePseudoConsole(coord, pipe_pty_in, pipe_pty_out, 0)
+                .context("CreatePseudoConsole failed")?;
+
+            // Close handles that the pseudoconsole now owns
+            let _ = CloseHandle(pipe_pty_in);
+            let _ = CloseHandle(pipe_pty_out);
+
+            // Prepare startup info with pseudoconsole
+            let mut attr_list_size: usize = 0;
+            let _ = InitializeProcThreadAttributeList(
+                LPPROC_THREAD_ATTRIBUTE_LIST(ptr::null_mut()),
+                1,
+                0,
+                &mut attr_list_size,
+            );
+
+            let attr_list_buf = vec![0u8; attr_list_size];
+            let attr_list = LPPROC_THREAD_ATTRIBUTE_LIST(attr_list_buf.as_ptr() as *mut _);
+            InitializeProcThreadAttributeList(attr_list, 1, 0, &mut attr_list_size)
+                .context("InitializeProcThreadAttributeList failed")?;
+
+            UpdateProcThreadAttribute(
+                attr_list,
+                0,
+                PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE as usize,
+                Some(hpc.0 as *const _),
+                std::mem::size_of::<HPCON>(),
+                None,
+                None,
+            )
+            .context("UpdateProcThreadAttribute failed")?;
+
+            let mut startup_info = STARTUPINFOEXW {
+                StartupInfo: std::mem::zeroed(),
+                lpAttributeList: attr_list,
+            };
+            startup_info.StartupInfo.cb = std::mem::size_of::<STARTUPINFOEXW>() as u32;
+
+            // Build command line
+            let cmdline = if args.is_empty() {
+                command.to_string()
+            } else {
+                format!("{} {}", command, args.join(" "))
+            };
+            let cmdline_wide: Vec<u16> = cmdline.encode_utf16().chain(std::iter::once(0)).collect();
+
+            let mut process_info = PROCESS_INFORMATION::default();
+
+            CreateProcessW(
+                None,
+                windows::core::PWSTR(cmdline_wide.as_ptr() as *mut _),
+                None,
+                None,
+                FALSE,
+                EXTENDED_STARTUPINFO_PRESENT,
+                None,
+                None,
+                &startup_info.StartupInfo,
+                &mut process_info,
+            )
+            .context("CreateProcessW failed")?;
+
+            let child_pid = process_info.dwProcessId;
+
+            Ok(Self {
+                hpc,
+                pipe_in: pipe_to_pty,
+                pipe_out: pipe_from_pty,
+                process: process_info.hProcess,
+                thread: process_info.hThread,
+                child_pid,
+            })
+        }
+    }
+
+    /// Read from PTY output pipe
+    pub fn read(&self, buf: &mut [u8]) -> Result<usize, PtyReadError> {
+        unsafe {
+            let mut bytes_read: u32 = 0;
+            let result = ReadFile(self.pipe_out, Some(buf), Some(&mut bytes_read), None);
+            if result.is_ok() {
+                if bytes_read == 0 {
+                    Err(PtyReadError::Eof)
+                } else {
+                    Ok(bytes_read as usize)
+                }
+            } else {
+                let err = std::io::Error::last_os_error();
+                if err.raw_os_error() == Some(109) {
+                    // ERROR_BROKEN_PIPE
+                    Err(PtyReadError::Eof)
+                } else {
+                    Err(PtyReadError::Other(format!("ReadFile failed: {}", err)))
+                }
+            }
+        }
+    }
+
+    /// Write to PTY input pipe
+    pub fn write(&self, data: &[u8]) -> Result<()> {
+        unsafe {
+            let mut written: u32 = 0;
+            let mut offset = 0;
+            while offset < data.len() {
+                let result = WriteFile(
+                    self.pipe_in,
+                    Some(&data[offset..]),
+                    Some(&mut written),
+                    None,
+                );
+                if result.is_err() {
+                    anyhow::bail!("WriteFile failed: {}", std::io::Error::last_os_error());
+                }
+                offset += written as usize;
+            }
+            Ok(())
+        }
+    }
+
+    /// Write to PTY, draining output when buffer is full.
+    /// On Windows with ConPTY pipes, this is simpler than Unix since
+    /// the pipe buffering handles most cases, but we still drain to prevent deadlock.
+    pub fn write_draining(&self, data: &[u8], drain_buffer: &mut Vec<u8>) -> Result<()> {
+        // On Windows, pipes have their own buffering.
+        // We do a simple write + drain approach.
+        let mut read_buf = [0u8; 65536];
+
+        // First drain any available output
+        loop {
+            let mut bytes_read: u32 = 0;
+            let has_data = unsafe {
+                // Peek to see if there's data without blocking
+                let mut avail: u32 = 0;
+                windows::Win32::System::Pipes::PeekNamedPipe(
+                    self.pipe_out,
+                    None,
+                    0,
+                    None,
+                    Some(&mut avail),
+                    None,
+                )
+                .is_ok()
+                    && avail > 0
+            };
+            if !has_data {
+                break;
+            }
+            unsafe {
+                if ReadFile(
+                    self.pipe_out,
+                    Some(&mut read_buf),
+                    Some(&mut bytes_read),
+                    None,
+                )
+                .is_ok()
+                    && bytes_read > 0
+                {
+                    drain_buffer.extend_from_slice(&read_buf[..bytes_read as usize]);
+                } else {
+                    break;
+                }
+            }
+        }
+
+        // Then write
+        self.write(data)
+    }
+
+    /// Set the PTY window size
+    pub fn set_size(&self, size: TerminalSize) -> Result<()> {
+        let coord = COORD {
+            X: size.cols as i16,
+            Y: size.rows as i16,
+        };
+        unsafe {
+            ResizePseudoConsole(self.hpc, coord).context("ResizePseudoConsole failed")?;
+        }
+        Ok(())
+    }
+
+    /// Get the child process ID
+    pub fn child_pid(&self) -> u32 {
+        self.child_pid
+    }
+
+    /// Send a signal to the child process
+    pub fn signal(&self, _sig: PlatformSignal) {
+        // Windows doesn't have Unix-style signals.
+        // The pseudoconsole forwards Ctrl+C automatically.
+    }
+
+    /// Wait for child to exit
+    pub fn wait(&mut self) -> Result<i32> {
+        unsafe {
+            WaitForSingleObject(self.process, u32::MAX);
+            let mut exit_code: u32 = 0;
+            GetExitCodeProcess(self.process, &mut exit_code)
+                .context("GetExitCodeProcess failed")?;
+            Ok(exit_code as i32)
+        }
+    }
+
+    /// Get pipe handle for polling
+    pub fn output_handle(&self) -> HANDLE {
+        self.pipe_out
+    }
+}
+
+impl Drop for Pty {
+    fn drop(&mut self) {
+        unsafe {
+            ClosePseudoConsole(self.hpc);
+            let _ = CloseHandle(self.pipe_in);
+            let _ = CloseHandle(self.pipe_out);
+            let _ = CloseHandle(self.process);
+            let _ = CloseHandle(self.thread);
+        }
+    }
+}
+
+/// Console control handler for Ctrl+C, etc.
+unsafe extern "system" fn console_ctrl_handler(ctrl_type: u32) -> BOOL {
+    match ctrl_type {
+        0 => {
+            // CTRL_C_EVENT
+            CTRL_C_RECEIVED.store(true, Ordering::SeqCst);
+            TRUE
+        }
+        1 => {
+            // CTRL_BREAK_EVENT
+            CTRL_BREAK_RECEIVED.store(true, Ordering::SeqCst);
+            TRUE
+        }
+        _ => FALSE,
+    }
+}
+
+/// Terminal raw mode guard - restores original mode on drop
+pub struct RawModeGuard {
+    original: Option<OriginalTerminalState>,
+}
+
+impl RawModeGuard {
+    /// Enable raw mode and return guard that restores on drop
+    pub fn new() -> Result<Self> {
+        let original = setup_raw_mode()?;
+        Ok(Self { original })
+    }
+
+    /// Take ownership of the original state (for manual restoration)
+    pub fn take(mut self) -> Option<OriginalTerminalState> {
+        self.original.take()
+    }
+}
+
+impl Drop for RawModeGuard {
+    fn drop(&mut self) {
+        if let Some(ref state) = self.original {
+            restore_terminal(state);
+        }
+    }
+}
+
+/// Restore terminal from raw mode
+pub fn restore_terminal(state: &OriginalTerminalState) {
+    unsafe {
+        if let Ok(stdin) = GetStdHandle(STD_INPUT_HANDLE) {
+            let _ = SetConsoleMode(stdin, state.stdin_mode);
+        }
+        if let Ok(stdout) = GetStdHandle(STD_OUTPUT_HANDLE) {
+            let _ = SetConsoleMode(stdout, state.stdout_mode);
+        }
+    }
+}
+
+/// Check if stdin is a TTY (console)
+pub fn is_stdin_tty() -> bool {
+    unsafe {
+        if let Ok(stdin) = GetStdHandle(STD_INPUT_HANDLE) {
+            let mut mode = CONSOLE_MODE::default();
+            GetConsoleMode(stdin, &mut mode).is_ok()
+        } else {
+            false
+        }
+    }
+}
+
+/// Get the current terminal size
+pub fn get_terminal_size() -> Result<TerminalSize> {
+    unsafe {
+        let stdout = GetStdHandle(STD_OUTPUT_HANDLE).context("GetStdHandle failed")?;
+        let mut csbi = CONSOLE_SCREEN_BUFFER_INFO::default();
+        if GetConsoleScreenBufferInfo(stdout, &mut csbi).is_ok() {
+            let cols = (csbi.srWindow.Right - csbi.srWindow.Left + 1) as u16;
+            let rows = (csbi.srWindow.Bottom - csbi.srWindow.Top + 1) as u16;
+            Ok(TerminalSize { rows, cols })
+        } else {
+            Ok(TerminalSize::default())
+        }
+    }
+}
+
+/// Setup console control handlers
+pub fn setup_signal_handlers() -> Result<()> {
+    unsafe {
+        SetConsoleCtrlHandler(Some(console_ctrl_handler), TRUE)
+            .context("SetConsoleCtrlHandler failed")?;
+    }
+    Ok(())
+}
+
+/// Check and clear pending signals
+pub fn check_signals() -> Vec<PlatformSignal> {
+    let mut signals = Vec::new();
+    if CTRL_C_RECEIVED.swap(false, Ordering::SeqCst) {
+        signals.push(PlatformSignal::Interrupt);
+    }
+    if CTRL_BREAK_RECEIVED.swap(false, Ordering::SeqCst) {
+        signals.push(PlatformSignal::Terminate);
+    }
+    // Note: Windows doesn't have SIGWINCH. Window resize is detected
+    // by polling terminal size changes.
+    signals
+}
+
+/// Poll for I/O events
+pub fn poll_io(pty: &Pty, timeout_ms: u16) -> Result<PollResult> {
+    unsafe {
+        let handles = [pty.output_handle()];
+
+        let result = WaitForMultipleObjects(&handles, FALSE, timeout_ms as u32);
+
+        match result {
+            WAIT_TIMEOUT => {
+                if has_console_input()? {
+                    return Ok(PollResult::StdinReadable);
+                }
+                Ok(PollResult::Timeout)
+            }
+            WAIT_OBJECT_0 => {
+                if has_console_input()? {
+                    Ok(PollResult::BothReadable)
+                } else {
+                    Ok(PollResult::PtyReadable)
+                }
+            }
+            WAIT_FAILED => {
+                anyhow::bail!(
+                    "WaitForMultipleObjects failed: {}",
+                    std::io::Error::last_os_error()
+                );
+            }
+            _ => Ok(PollResult::Timeout),
+        }
+    }
+}
+
+/// Poll stdin for input with a timeout (used for Kitty detection)
+pub fn poll_stdin(timeout_ms: u16) -> Result<bool> {
+    // Wait briefly, then check console input
+    std::thread::sleep(std::time::Duration::from_millis(timeout_ms as u64));
+    has_console_input().map_err(Into::into)
+}
+
+/// Check if console has pending input
+fn has_console_input() -> Result<bool> {
+    unsafe {
+        let stdin = GetStdHandle(STD_INPUT_HANDLE).context("GetStdHandle failed")?;
+        let mut count: u32 = 0;
+        if GetNumberOfConsoleInputEvents(stdin, &mut count).is_ok() && count > 0 {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+}
+
+/// Write data to stdout
+pub fn write_stdout(data: &[u8]) -> Result<()> {
+    let mut stdout = io::stdout().lock();
+    stdout.write_all(data)?;
+    stdout.flush()?;
+    Ok(())
+}
+
+/// Read from stdin
+pub fn read_stdin(buf: &mut [u8]) -> io::Result<usize> {
+    let mut stdin = io::stdin().lock();
+    stdin.read(buf)
+}
+
+// ============ Internal helpers ============
+
+fn setup_raw_mode() -> Result<Option<OriginalTerminalState>> {
+    unsafe {
+        let stdin = GetStdHandle(STD_INPUT_HANDLE).context("GetStdHandle stdin failed")?;
+        let stdout = GetStdHandle(STD_OUTPUT_HANDLE).context("GetStdHandle stdout failed")?;
+
+        let mut stdin_mode = CONSOLE_MODE::default();
+        let mut stdout_mode = CONSOLE_MODE::default();
+
+        // If not a console, return None
+        if GetConsoleMode(stdin, &mut stdin_mode).is_err() {
+            return Ok(None);
+        }
+        let _ = GetConsoleMode(stdout, &mut stdout_mode);
+
+        let original = OriginalTerminalState {
+            stdin_mode,
+            stdout_mode,
+        };
+
+        // Set raw mode for input: disable line input, echo, and processed input
+        // Enable virtual terminal input for escape sequences
+        let new_stdin_mode = CONSOLE_MODE(
+            (stdin_mode.0
+                & !(ENABLE_LINE_INPUT.0 | ENABLE_ECHO_INPUT.0 | ENABLE_PROCESSED_INPUT.0))
+                | ENABLE_VIRTUAL_TERMINAL_INPUT.0,
+        );
+        SetConsoleMode(stdin, new_stdin_mode).context("SetConsoleMode stdin failed")?;
+
+        // Enable virtual terminal processing for output (ANSI escape sequences)
+        let new_stdout_mode = CONSOLE_MODE(stdout_mode.0 | ENABLE_VIRTUAL_TERMINAL_PROCESSING.0);
+        let _ = SetConsoleMode(stdout, new_stdout_mode);
+
+        Ok(Some(original))
+    }
+}

--- a/crates/claude-chill/src/proxy.rs
+++ b/crates/claude-chill/src/proxy.rs
@@ -6,47 +6,20 @@ use crate::escape_sequences::{
 };
 use crate::history_filter::HistoryFilter;
 use crate::line_buffer::LineBuffer;
+use crate::platform::{self, PlatformSignal, PollResult, Pty, PtyReadError, RawModeGuard};
 use anyhow::{Context, Result};
 use log::debug;
 use memchr::memmem;
-use nix::errno::Errno;
-use nix::fcntl::{FcntlArg, OFlag, fcntl};
-use nix::poll::{PollFd, PollFlags, PollTimeout, poll};
-use nix::pty::{Winsize, openpty};
-use nix::sys::signal::{SaFlags, SigAction, SigHandler, SigSet, Signal, kill, sigaction};
-use nix::sys::termios::{SetArg, Termios, cfmakeraw, tcgetattr, tcsetattr};
-use nix::unistd::{Pid, isatty, read, write};
-use std::io;
-use std::os::fd::{AsFd, AsRawFd, BorrowedFd, OwnedFd};
-use std::os::unix::process::CommandExt;
-use std::process::{Child, Command, ExitStatus};
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant};
 use termwiz::escape::Action;
 use termwiz::escape::csi::{CSI, Keyboard};
 use termwiz::escape::parser::Parser as TermwizParser;
-
-static SIGWINCH_RECEIVED: AtomicBool = AtomicBool::new(false);
-static SIGINT_RECEIVED: AtomicBool = AtomicBool::new(false);
-static SIGTERM_RECEIVED: AtomicBool = AtomicBool::new(false);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum SequenceMatch {
     Complete,
     Partial,
     None,
-}
-
-extern "C" fn handle_sigwinch(_: libc::c_int) {
-    SIGWINCH_RECEIVED.store(true, Ordering::SeqCst);
-}
-
-extern "C" fn handle_sigint(_: libc::c_int) {
-    SIGINT_RECEIVED.store(true, Ordering::SeqCst);
-}
-
-extern "C" fn handle_sigterm(_: libc::c_int) {
-    SIGTERM_RECEIVED.store(true, Ordering::SeqCst);
 }
 
 pub struct ProxyConfig {
@@ -69,37 +42,13 @@ impl Default for ProxyConfig {
     }
 }
 
-struct TerminalGuard {
-    original_termios: Option<Termios>,
-}
-
-impl TerminalGuard {
-    fn new() -> Result<Self> {
-        let original_termios = setup_raw_mode()?;
-        Ok(Self { original_termios })
-    }
-
-    fn take(mut self) -> Option<Termios> {
-        self.original_termios.take()
-    }
-}
-
-impl Drop for TerminalGuard {
-    fn drop(&mut self) {
-        if let Some(ref termios) = self.original_termios {
-            let _ = tcsetattr(io::stdin(), SetArg::TCSANOW, termios);
-        }
-    }
-}
-
 const RENDER_DELAY_MS: u64 = 5;
 const SYNC_BLOCK_DELAY_MS: u64 = 50;
 
 pub struct Proxy {
     config: ProxyConfig,
-    pty_master: OwnedFd,
-    child: Child,
-    original_termios: Option<Termios>,
+    pty: Pty,
+    original_terminal_state: Option<platform::OriginalTerminalState>,
     history: LineBuffer,
     history_filter: HistoryFilter,
     vt_parser: vt100::Parser,
@@ -161,22 +110,18 @@ fn detect_kitty_support() -> (bool, u32) {
     drop(stdout_lock);
 
     // Read responses with timeout using termwiz parser
-    let stdin = std::io::stdin();
     let mut parser = TermwizParser::new();
     let mut buf = [0u8; 256];
     let mut kitty_supported = false;
     let mut kitty_flags: u32 = 0;
     let start = std::time::Instant::now();
     let timeout = std::time::Duration::from_millis(500);
-    let poll_interval = PollTimeout::from(50u16);
 
     while start.elapsed() < timeout {
-        let mut poll_fd = [PollFd::new(stdin.as_fd(), PollFlags::POLLIN)];
-
-        match poll(&mut poll_fd, poll_interval) {
-            Ok(0) => continue,
-            Ok(_) => {
-                match read(stdin.as_fd(), &mut buf) {
+        match platform::poll_stdin(50) {
+            Ok(false) => continue,
+            Ok(true) => {
+                match platform::read_stdin(&mut buf) {
                     Ok(0) => continue,
                     Ok(n) => {
                         let actions = parser.parse_as_vec(&buf[..n]);
@@ -202,7 +147,7 @@ fn detect_kitty_support() -> (bool, u32) {
                             }
                         }
                     }
-                    Err(e) if e == Errno::EAGAIN || e == Errno::EWOULDBLOCK => continue,
+                    Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => continue,
                     Err(_) => break,
                 }
             }
@@ -219,58 +164,25 @@ fn detect_kitty_support() -> (bool, u32) {
 
 impl Proxy {
     pub fn spawn(command: &str, args: &[&str], config: ProxyConfig) -> Result<Self> {
-        let winsize = get_terminal_size()?;
-        let pty = openpty(&winsize, None).context("openpty failed")?;
+        let term_size = platform::get_terminal_size()?;
 
-        let terminal_guard = TerminalGuard::new()?;
-        setup_signal_handlers()?;
+        let raw_mode_guard = RawModeGuard::new()?;
+        platform::setup_signal_handlers()?;
 
         // Detect Kitty support before spawning child
         // If flags > 0, terminal is already in Kitty mode (inherited from parent)
         let (kitty_supported, kitty_initial_flags) = detect_kitty_support();
         let kitty_initial_stack = if kitty_initial_flags > 0 { 1 } else { 0 };
 
-        let slave_fd = pty.slave.as_raw_fd();
-
-        let child = unsafe {
-            Command::new(command)
-                .args(args)
-                .pre_exec(move || {
-                    if libc::setsid() == -1 {
-                        return Err(io::Error::last_os_error());
-                    }
-                    if libc::ioctl(slave_fd, libc::TIOCSCTTY as libc::c_ulong, 0) == -1 {
-                        return Err(io::Error::last_os_error());
-                    }
-                    if libc::dup2(slave_fd, 0) == -1 {
-                        return Err(io::Error::last_os_error());
-                    }
-                    if libc::dup2(slave_fd, 1) == -1 {
-                        return Err(io::Error::last_os_error());
-                    }
-                    if libc::dup2(slave_fd, 2) == -1 {
-                        return Err(io::Error::last_os_error());
-                    }
-                    if slave_fd > 2 {
-                        libc::close(slave_fd);
-                    }
-                    Ok(())
-                })
-                .spawn()
-                .context("spawn failed")?
-        };
-
-        drop(pty.slave);
-        set_nonblocking(&pty.master)?;
+        let pty = Pty::spawn(command, args, term_size).context("PTY spawn failed")?;
 
         // Enable bracketed paste on the real terminal so tmux/Ghostty wraps
         // paste content in \x1b[200~ ... \x1b[201~ markers. Without this,
         // the child app's \x1b[?2004h gets eaten by the VT renderer before
         // it reaches the terminal, and pastes arrive as plain keystrokes.
-        let stdout_fd = io::stdout();
-        write_all(&stdout_fd, BRACKETED_PASTE_ENABLE)?;
+        platform::write_stdout(BRACKETED_PASTE_ENABLE)?;
 
-        let vt_parser = vt100::Parser::new(winsize.ws_row, winsize.ws_col, 0);
+        let vt_parser = vt100::Parser::new(term_size.rows, term_size.cols, 0);
 
         // Seed history with clear screen so replay starts fresh
         let mut history = LineBuffer::new(config.max_history_lines);
@@ -285,9 +197,8 @@ impl Proxy {
             history,
             history_filter: HistoryFilter::new(),
             config,
-            pty_master: pty.master,
-            child,
-            original_termios: terminal_guard.take(),
+            pty,
+            original_terminal_state: raw_mode_guard.take(),
             vt_parser,
             vt_prev_screen: None,
             last_output_time: None,
@@ -323,99 +234,102 @@ impl Proxy {
     }
 
     pub fn run(&mut self) -> Result<i32> {
-        let stdin_fd = io::stdin();
-        let stdout_fd = io::stdout();
-
         let mut buf = [0u8; 65536];
 
         loop {
-            if SIGWINCH_RECEIVED.swap(false, Ordering::SeqCst) {
-                self.forward_winsize()?;
+            // Check for platform signals
+            for signal in platform::check_signals() {
+                match signal {
+                    PlatformSignal::Resize => {
+                        self.forward_winsize()?;
+                    }
+                    PlatformSignal::Interrupt => {
+                        self.pty.signal(PlatformSignal::Interrupt);
+                    }
+                    PlatformSignal::Terminate => {
+                        self.pty.signal(PlatformSignal::Terminate);
+                    }
+                }
             }
-            if SIGINT_RECEIVED.swap(false, Ordering::SeqCst) {
-                self.forward_signal(Signal::SIGINT);
-            }
-            if SIGTERM_RECEIVED.swap(false, Ordering::SeqCst) {
-                self.forward_signal(Signal::SIGTERM);
-            }
-
-            let master_fd = unsafe { BorrowedFd::borrow_raw(self.pty_master.as_raw_fd()) };
-            let stdin_borrowed = unsafe { BorrowedFd::borrow_raw(stdin_fd.as_raw_fd()) };
-
-            let mut poll_fds = [
-                PollFd::new(master_fd, PollFlags::POLLIN),
-                PollFd::new(stdin_borrowed, PollFlags::POLLIN),
-            ];
 
             let poll_timeout_ms = self
                 .time_until_render()
                 .map(|d| d.as_millis().min(100) as u16)
                 .unwrap_or(100);
 
-            match poll(&mut poll_fds, PollTimeout::from(poll_timeout_ms)) {
-                Ok(0) => {
-                    self.flush_pending_vt_render(&stdout_fd)?;
-                    self.check_auto_lookback(&stdout_fd)?;
+            let poll_result = platform::poll_io(&self.pty, poll_timeout_ms)?;
+
+            match poll_result {
+                PollResult::Timeout => {
+                    self.flush_pending_vt_render()?;
+                    self.check_auto_lookback()?;
                     continue;
                 }
-                Ok(_) => {}
-                Err(Errno::EINTR) => continue,
-                Err(e) => anyhow::bail!("poll failed: {}", e),
-            }
-
-            self.flush_pending_vt_render(&stdout_fd)?;
-
-            if let Some(revents) = poll_fds[0].revents() {
-                if revents.contains(PollFlags::POLLIN) {
-                    match nix_read(&self.pty_master, &mut buf) {
-                        Ok(0) => break,
-                        Ok(n) => self.process_output(&buf[..n], &stdout_fd)?,
-                        Err(Errno::EAGAIN) => {}
-                        Err(Errno::EIO) => break,
-                        Err(e) => anyhow::bail!("read from pty failed: {}", e),
-                    }
+                PollResult::Interrupted => continue,
+                PollResult::PtyHangup => break,
+                PollResult::PtyReadable => {
+                    self.flush_pending_vt_render()?;
+                    self.handle_pty_read(&mut buf)?;
                 }
-                if revents.contains(PollFlags::POLLHUP) {
-                    break;
+                PollResult::StdinReadable => {
+                    self.flush_pending_vt_render()?;
+                    self.handle_stdin_read(&mut buf)?;
                 }
-            }
-
-            if let Some(revents) = poll_fds[1].revents()
-                && revents.contains(PollFlags::POLLIN)
-            {
-                match nix_read(&stdin_fd, &mut buf) {
-                    Ok(0) => break,
-                    Ok(n) => {
-                        self.process_input(&buf[..n], &stdout_fd)?;
-                        if !self.pty_drain_buffer.is_empty() {
-                            let drained = std::mem::take(&mut self.pty_drain_buffer);
-                            self.process_output(&drained, &stdout_fd)?;
-                        }
+                PollResult::BothReadable => {
+                    self.flush_pending_vt_render()?;
+                    // Handle PTY first, then stdin
+                    if self.handle_pty_read(&mut buf)? {
+                        break;
                     }
-                    Err(Errno::EAGAIN) => {}
-                    Err(e) => anyhow::bail!("read from stdin failed: {}", e),
+                    self.handle_stdin_read(&mut buf)?;
                 }
             }
         }
 
         // Final render before exit
         if self.vt_render_pending {
-            self.render_vt_screen(&stdout_fd)?;
+            self.render_vt_screen()?;
         }
 
-        self.wait_child()
+        self.pty.wait()
     }
 
-    fn process_output<F: AsFd>(&mut self, data: &[u8], stdout_fd: &F) -> Result<()> {
-        self.process_output_inner(data, stdout_fd, true)
+    /// Handle reading from PTY. Returns true if PTY closed (should break loop).
+    fn handle_pty_read(&mut self, buf: &mut [u8]) -> Result<bool> {
+        match self.pty.read(buf) {
+            Ok(0) => Ok(true),
+            Ok(n) => {
+                self.process_output(&buf[..n])?;
+                Ok(false)
+            }
+            Err(PtyReadError::WouldBlock) => Ok(false),
+            Err(PtyReadError::Eof) => Ok(true),
+            Err(PtyReadError::Other(msg)) => anyhow::bail!("{}", msg),
+        }
     }
 
-    fn process_output_inner<F: AsFd>(
-        &mut self,
-        data: &[u8],
-        stdout_fd: &F,
-        feed_vt: bool,
-    ) -> Result<()> {
+    /// Handle reading from stdin. Returns true if stdin closed (should break loop).
+    fn handle_stdin_read(&mut self, buf: &mut [u8]) -> Result<bool> {
+        match platform::read_stdin(buf) {
+            Ok(0) => Ok(true),
+            Ok(n) => {
+                self.process_input(&buf[..n])?;
+                if !self.pty_drain_buffer.is_empty() {
+                    let drained = std::mem::take(&mut self.pty_drain_buffer);
+                    self.process_output(&drained)?;
+                }
+                Ok(false)
+            }
+            Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => Ok(false),
+            Err(e) => anyhow::bail!("read from stdin failed: {}", e),
+        }
+    }
+
+    fn process_output(&mut self, data: &[u8]) -> Result<()> {
+        self.process_output_inner(data, true)
+    }
+
+    fn process_output_inner(&mut self, data: &[u8], feed_vt: bool) -> Result<()> {
         debug!(
             "process_output: len={} in_alt={} in_lookback={} feed_vt={}",
             data.len(),
@@ -430,7 +344,7 @@ impl Proxy {
             if feed_vt {
                 self.vt_parser.process(data);
             }
-            return self.process_output_alt_screen(data, stdout_fd);
+            return self.process_output_alt_screen(data);
         }
 
         if self.in_lookback_mode {
@@ -468,8 +382,8 @@ impl Proxy {
                 self.in_alternate_screen = true;
                 let seq_len = self.alt_screen_enter_len(&data[pos + alt_pos..]);
                 // Write alt screen enter directly
-                self.write_to_terminal(stdout_fd, &data[pos + alt_pos..pos + alt_pos + seq_len])?;
-                return self.process_output_alt_screen(&data[pos + alt_pos + seq_len..], stdout_fd);
+                self.write_to_terminal(&data[pos + alt_pos..pos + alt_pos + seq_len])?;
+                return self.process_output_alt_screen(&data[pos + alt_pos + seq_len..]);
             }
 
             if self.in_sync_block {
@@ -504,21 +418,21 @@ impl Proxy {
         Ok(())
     }
 
-    fn process_output_alt_screen<F: AsFd>(&mut self, data: &[u8], stdout_fd: &F) -> Result<()> {
+    fn process_output_alt_screen(&mut self, data: &[u8]) -> Result<()> {
         if let Some(exit_pos) = self.find_alt_screen_exit(data) {
             debug!(
                 "process_output_alt_screen: ALT_SCREEN_EXIT detected at pos={}",
                 exit_pos
             );
-            self.write_to_terminal(stdout_fd, &data[..exit_pos])?;
+            self.write_to_terminal(&data[..exit_pos])?;
             let seq_len = self.alt_screen_exit_len(&data[exit_pos..]);
-            self.write_to_terminal(stdout_fd, &data[exit_pos..exit_pos + seq_len])?;
+            self.write_to_terminal(&data[exit_pos..exit_pos + seq_len])?;
             self.in_alternate_screen = false;
 
             // Force full VT render to restore main screen content
             debug!("process_output_alt_screen: rendering VT screen after alt exit");
             self.vt_prev_screen = None;
-            self.render_vt_screen(stdout_fd)?;
+            self.render_vt_screen()?;
 
             // Data after ALT_EXIT was already fed to VT and history when we processed
             // the alt screen chunk, so we just need to check for more alt screen transitions
@@ -527,16 +441,16 @@ impl Proxy {
                 // Check if there's another alt screen enter in the remaining data
                 if self.find_alt_screen_enter(remaining).is_some() {
                     // Need to process for alt screen detection, but skip VT/history feed
-                    return self.process_output_check_alt_only(remaining, stdout_fd);
+                    return self.process_output_check_alt_only(remaining);
                 }
             }
             return Ok(());
         }
-        self.write_to_terminal(stdout_fd, data)
+        self.write_to_terminal(data)
     }
 
     /// Check for alt screen transitions without re-feeding VT/history
-    fn process_output_check_alt_only<F: AsFd>(&mut self, data: &[u8], stdout_fd: &F) -> Result<()> {
+    fn process_output_check_alt_only(&mut self, data: &[u8]) -> Result<()> {
         if let Some(alt_pos) = self.find_alt_screen_enter(data) {
             debug!(
                 "process_output_check_alt_only: ALT_SCREEN_ENTER at pos={}",
@@ -544,8 +458,8 @@ impl Proxy {
             );
             self.in_alternate_screen = true;
             let seq_len = self.alt_screen_enter_len(&data[alt_pos..]);
-            self.write_to_terminal(stdout_fd, &data[alt_pos..alt_pos + seq_len])?;
-            return self.process_output_alt_screen(&data[alt_pos + seq_len..], stdout_fd);
+            self.write_to_terminal(&data[alt_pos..alt_pos + seq_len])?;
+            return self.process_output_alt_screen(&data[alt_pos + seq_len..]);
         }
         Ok(())
     }
@@ -593,14 +507,14 @@ impl Proxy {
     }
 
     /// Write data to the terminal and track Kitty keyboard protocol state
-    fn write_to_terminal<F: AsFd>(&mut self, stdout_fd: &F, data: &[u8]) -> Result<()> {
+    fn write_to_terminal(&mut self, data: &[u8]) -> Result<()> {
         Self::update_kitty_mode_helper(
             &mut self.kitty_output_parser,
             &mut self.kitty_mode_stack,
             self.kitty_mode_supported,
             data,
         );
-        write_all(stdout_fd, data)
+        platform::write_stdout(data)
     }
 
     fn update_kitty_mode_helper(
@@ -676,7 +590,7 @@ impl Proxy {
         self.history.push_bytes(&filtered);
     }
 
-    fn flush_pending_vt_render<F: AsFd>(&mut self, stdout_fd: &F) -> Result<()> {
+    fn flush_pending_vt_render(&mut self) -> Result<()> {
         if !self.vt_render_pending || self.in_lookback_mode || self.in_alternate_screen {
             return Ok(());
         }
@@ -694,7 +608,7 @@ impl Proxy {
         };
 
         if elapsed >= delay {
-            self.render_vt_screen(stdout_fd)?;
+            self.render_vt_screen()?;
         }
 
         Ok(())
@@ -723,7 +637,7 @@ impl Proxy {
         }
     }
 
-    fn render_vt_screen<F: AsFd>(&mut self, stdout_fd: &F) -> Result<()> {
+    fn render_vt_screen(&mut self) -> Result<()> {
         let is_diff = self.vt_prev_screen.is_some();
         self.output_buffer.clear();
         self.output_buffer.extend_from_slice(SYNC_START);
@@ -758,7 +672,7 @@ impl Proxy {
             self.kitty_mode_supported,
             &self.output_buffer,
         );
-        write_all(stdout_fd, &self.output_buffer)?;
+        platform::write_stdout(&self.output_buffer)?;
 
         // Store current screen for next diff
         self.vt_prev_screen = Some(self.vt_parser.screen().clone());
@@ -767,7 +681,7 @@ impl Proxy {
         Ok(())
     }
 
-    fn check_auto_lookback<F: AsFd>(&mut self, stdout_fd: &F) -> Result<()> {
+    fn check_auto_lookback(&mut self) -> Result<()> {
         if self.auto_lookback_timeout.is_zero() {
             return Ok(());
         }
@@ -804,12 +718,12 @@ impl Proxy {
                 .map(|t| t.elapsed().as_millis())
                 .unwrap_or(0)
         );
-        self.dump_history(stdout_fd)?;
+        self.dump_history()?;
         self.last_auto_lookback_time = Some(Instant::now());
         Ok(())
     }
 
-    fn dump_history<F: AsFd>(&mut self, stdout_fd: &F) -> Result<()> {
+    fn dump_history(&mut self) -> Result<()> {
         debug!(
             "dump_history: history_bytes={} lines={}",
             self.history.total_bytes(),
@@ -825,8 +739,8 @@ impl Proxy {
             debug!("Failed to write history file: {}", e);
         }
 
-        self.write_to_terminal(stdout_fd, CLEAR_SCREEN)?;
-        self.write_to_terminal(stdout_fd, CURSOR_HOME)?;
+        self.write_to_terminal(CLEAR_SCREEN)?;
+        self.write_to_terminal(CURSOR_HOME)?;
         // Can't use write_to_terminal here due to borrow checker - can't pass
         // &self.output_buffer while also taking &mut self
         Self::update_kitty_mode_helper(
@@ -835,14 +749,14 @@ impl Proxy {
             self.kitty_mode_supported,
             &self.output_buffer,
         );
-        write_all(stdout_fd, &self.output_buffer)?;
+        platform::write_stdout(&self.output_buffer)?;
 
         // Force full VT render on next output since terminal now shows history
         self.vt_prev_screen = None;
         Ok(())
     }
 
-    fn process_input<F: AsFd>(&mut self, data: &[u8], stdout_fd: &F) -> Result<()> {
+    fn process_input(&mut self, data: &[u8]) -> Result<()> {
         self.last_stdin_time = Some(Instant::now());
 
         debug!(
@@ -852,7 +766,7 @@ impl Proxy {
 
         // In alternate screen, forward directly with deadlock prevention
         if self.in_alternate_screen {
-            return write_to_pty_draining(&self.pty_master, data, &mut self.pty_drain_buffer);
+            return self.pty.write_draining(data, &mut self.pty_drain_buffer);
         }
 
         // In bracketed paste, forward directly until paste end marker
@@ -868,15 +782,12 @@ impl Proxy {
 
             if let Some(pos) = self.paste_end_finder.find(search_data) {
                 let end = pos + BRACKETED_PASTE_END.len();
-                write_to_pty_draining(
-                    &self.pty_master,
-                    &search_data[..end],
-                    &mut self.pty_drain_buffer,
-                )?;
+                self.pty
+                    .write_draining(&search_data[..end], &mut self.pty_drain_buffer)?;
                 self.in_bracketed_paste = false;
                 debug!("process_input: bracketed paste ended");
                 if end < search_data.len() {
-                    return self.process_input(&search_data[end..], stdout_fd);
+                    return self.process_input(&search_data[end..]);
                 }
                 return Ok(());
             }
@@ -884,7 +795,8 @@ impl Proxy {
             let (forward, remainder) =
                 split_trailing_marker_prefix(search_data, BRACKETED_PASTE_END);
             if !forward.is_empty() {
-                write_to_pty_draining(&self.pty_master, forward, &mut self.pty_drain_buffer)?;
+                self.pty
+                    .write_draining(forward, &mut self.pty_drain_buffer)?;
             }
             self.paste_remainder.extend_from_slice(remainder);
             return Ok(());
@@ -895,7 +807,7 @@ impl Proxy {
             debug!("process_input: bracketed paste started");
             // Process any data before paste start through normal lookback matching
             if pos > 0 {
-                self.process_input_lookback(&data[..pos], stdout_fd)?;
+                self.process_input_lookback(&data[..pos])?;
             }
             self.in_bracketed_paste = true;
             let paste_data = &data[pos..];
@@ -905,33 +817,31 @@ impl Proxy {
                 && let Some(end_pos) = self.paste_end_finder.find(&paste_data[search_start..])
             {
                 let end = search_start + end_pos + BRACKETED_PASTE_END.len();
-                write_to_pty_draining(
-                    &self.pty_master,
-                    &paste_data[..end],
-                    &mut self.pty_drain_buffer,
-                )?;
+                self.pty
+                    .write_draining(&paste_data[..end], &mut self.pty_drain_buffer)?;
                 self.in_bracketed_paste = false;
                 debug!("process_input: bracketed paste ended (same chunk)");
                 if end < paste_data.len() {
-                    return self.process_input(&paste_data[end..], stdout_fd);
+                    return self.process_input(&paste_data[end..]);
                 }
                 return Ok(());
             }
             let (forward, remainder) =
                 split_trailing_marker_prefix(paste_data, BRACKETED_PASTE_END);
             if !forward.is_empty() {
-                write_to_pty_draining(&self.pty_master, forward, &mut self.pty_drain_buffer)?;
+                self.pty
+                    .write_draining(forward, &mut self.pty_drain_buffer)?;
             }
             self.paste_remainder.extend_from_slice(remainder);
             return Ok(());
         }
 
-        self.process_input_lookback(data, stdout_fd)
+        self.process_input_lookback(data)
     }
 
     /// Byte-by-byte input processing with lookback sequence matching.
     /// Only used for normal (non-paste, non-alt-screen) input.
-    fn process_input_lookback<F: AsFd>(&mut self, data: &[u8], stdout_fd: &F) -> Result<()> {
+    fn process_input_lookback(&mut self, data: &[u8]) -> Result<()> {
         let lookback_sequence = if self.kitty_mode_enabled() {
             self.config.lookback_sequence_kitty.clone()
         } else {
@@ -941,7 +851,7 @@ impl Proxy {
         for &byte in data {
             if self.in_lookback_mode && byte == 0x03 {
                 self.lookback_input_buffer.clear();
-                self.exit_lookback_mode(stdout_fd)?;
+                self.exit_lookback_mode()?;
                 continue;
             }
 
@@ -962,7 +872,7 @@ impl Proxy {
                 SequenceMatch::Complete => {
                     self.lookback_input_buffer.clear();
                     if self.in_lookback_mode {
-                        self.exit_lookback_mode(stdout_fd)?;
+                        self.exit_lookback_mode()?;
                     } else {
                         self.enter_lookback_mode()?;
                     }
@@ -975,7 +885,7 @@ impl Proxy {
                 SequenceMatch::None => {
                     // Not a lookback sequence - forward all buffered bytes
                     if !self.in_lookback_mode {
-                        write_all(&self.pty_master, &self.lookback_input_buffer)?;
+                        self.pty.write(&self.lookback_input_buffer.clone())?;
                     }
                     self.lookback_input_buffer.clear();
                 }
@@ -1021,21 +931,20 @@ impl Proxy {
             self.output_buffer.len()
         );
 
-        let stdout_fd = io::stdout();
-        write_all(&stdout_fd, CLEAR_SCREEN)?;
-        write_all(&stdout_fd, CURSOR_HOME)?;
-        write_all(&stdout_fd, &self.output_buffer)?;
+        platform::write_stdout(CLEAR_SCREEN)?;
+        platform::write_stdout(CURSOR_HOME)?;
+        platform::write_stdout(&self.output_buffer)?;
 
         let exit_msg = format!(
             "\r\n\x1b[7m--- LOOKBACK MODE: press {} or Ctrl+C to exit ---\x1b[0m\r\n",
             self.config.lookback_key
         );
-        write_all(&stdout_fd, exit_msg.as_bytes())?;
+        platform::write_stdout(exit_msg.as_bytes())?;
 
         Ok(())
     }
 
-    fn exit_lookback_mode<F: AsFd>(&mut self, stdout_fd: &F) -> Result<()> {
+    fn exit_lookback_mode(&mut self) -> Result<()> {
         debug!(
             "exit_lookback_mode: cached_len={}",
             self.lookback_cache.len()
@@ -1049,7 +958,7 @@ impl Proxy {
                 "exit_lookback_mode: processing {} cached bytes",
                 cached.len()
             );
-            self.process_output(&cached, stdout_fd)?;
+            self.process_output(&cached)?;
         }
 
         // Reset sync block state
@@ -1061,173 +970,39 @@ impl Proxy {
         // Force full render since terminal was showing history
         debug!("exit_lookback_mode: rendering VT screen");
         self.vt_prev_screen = None;
-        self.render_vt_screen(stdout_fd)?;
+        self.render_vt_screen()?;
 
         Ok(())
     }
 
     fn forward_winsize(&mut self) -> Result<()> {
-        if let Ok(winsize) = get_terminal_size() {
+        if let Ok(term_size) = platform::get_terminal_size() {
             debug!(
                 "forward_winsize: rows={} cols={}",
-                winsize.ws_row, winsize.ws_col
+                term_size.rows, term_size.cols
             );
             // Resize VT emulator
             self.vt_parser
                 .screen_mut()
-                .set_size(winsize.ws_row, winsize.ws_col);
+                .set_size(term_size.rows, term_size.cols);
             // Force full render on next frame since size changed
             self.vt_prev_screen = None;
             // Forward to child process
-            unsafe {
-                libc::ioctl(
-                    self.pty_master.as_raw_fd(),
-                    libc::TIOCSWINSZ as libc::c_ulong,
-                    &winsize,
-                );
-            }
+            self.pty.set_size(term_size)?;
         }
         Ok(())
-    }
-
-    fn forward_signal(&self, signal: Signal) {
-        let pid = Pid::from_raw(self.child.id() as i32);
-        let _ = kill(pid, signal);
-    }
-
-    fn wait_child(&mut self) -> Result<i32> {
-        match self.child.wait() {
-            Ok(status) => Ok(exit_code_from_status(status)),
-            Err(e) => anyhow::bail!("wait failed: {}", e),
-        }
     }
 }
 
 impl Drop for Proxy {
     fn drop(&mut self) {
         // Disable bracketed paste before restoring terminal
-        let stdout_fd = io::stdout();
-        let _ = write_all(&stdout_fd, BRACKETED_PASTE_DISABLE);
+        let _ = platform::write_stdout(BRACKETED_PASTE_DISABLE);
 
-        if let Some(ref termios) = self.original_termios {
-            let _ = tcsetattr(io::stdin(), SetArg::TCSANOW, termios);
+        if let Some(ref state) = self.original_terminal_state {
+            platform::restore_terminal(state);
         }
     }
-}
-
-fn get_terminal_size() -> Result<Winsize> {
-    let mut ws: Winsize = unsafe { std::mem::zeroed() };
-    let ret = unsafe {
-        libc::ioctl(
-            io::stdout().as_raw_fd(),
-            libc::TIOCGWINSZ as libc::c_ulong,
-            &mut ws,
-        )
-    };
-    if ret == -1 || ws.ws_row == 0 || ws.ws_col == 0 {
-        ws.ws_row = 24;
-        ws.ws_col = 80;
-    }
-    Ok(ws)
-}
-
-fn exit_code_from_status(status: ExitStatus) -> i32 {
-    use std::os::unix::process::ExitStatusExt;
-    if let Some(code) = status.code() {
-        code
-    } else if let Some(signal) = status.signal() {
-        128 + signal
-    } else {
-        1
-    }
-}
-
-fn setup_raw_mode() -> Result<Option<Termios>> {
-    let stdin = io::stdin();
-    if !isatty(&stdin).unwrap_or(false) {
-        return Ok(None);
-    }
-
-    let original = tcgetattr(&stdin).context("tcgetattr failed")?;
-    let mut raw = original.clone();
-    cfmakeraw(&mut raw);
-    tcsetattr(&stdin, SetArg::TCSANOW, &raw).context("tcsetattr failed")?;
-    Ok(Some(original))
-}
-
-fn setup_signal_handler(signal: Signal, handler: extern "C" fn(libc::c_int)) -> Result<()> {
-    let action = SigAction::new(
-        SigHandler::Handler(handler),
-        SaFlags::SA_RESTART,
-        SigSet::empty(),
-    );
-    unsafe { sigaction(signal, &action) }.context(format!("sigaction {:?} failed", signal))?;
-    Ok(())
-}
-
-fn setup_signal_handlers() -> Result<()> {
-    setup_signal_handler(Signal::SIGWINCH, handle_sigwinch)?;
-    setup_signal_handler(Signal::SIGINT, handle_sigint)?;
-    setup_signal_handler(Signal::SIGTERM, handle_sigterm)?;
-    Ok(())
-}
-
-fn set_nonblocking<Fd: AsFd>(fd: &Fd) -> Result<()> {
-    let flags = fcntl(fd.as_fd(), FcntlArg::F_GETFL).context("fcntl F_GETFL failed")?;
-    let flags = OFlag::from_bits_truncate(flags);
-    fcntl(fd.as_fd(), FcntlArg::F_SETFL(flags | OFlag::O_NONBLOCK))
-        .context("fcntl F_SETFL failed")?;
-    Ok(())
-}
-
-fn write_all<F: AsFd>(fd: &F, data: &[u8]) -> Result<()> {
-    let mut written = 0;
-    while written < data.len() {
-        match write(fd, &data[written..]) {
-            Ok(n) => written += n,
-            Err(Errno::EAGAIN) | Err(Errno::EINTR) => continue,
-            Err(e) => anyhow::bail!("write failed: {}", e),
-        }
-    }
-    Ok(())
-}
-
-/// Write data to the pty master, draining child output to stdout when the
-/// pty buffer is full. This prevents the classic pty deadlock where both
-/// sides block on full buffers (stdin→pty blocks because pty buffer is full,
-/// child→pty blocks because its output buffer is also full).
-fn write_to_pty_draining<P: AsFd>(pty: &P, data: &[u8], drain_buffer: &mut Vec<u8>) -> Result<()> {
-    let mut written = 0;
-    let mut read_buf = [0u8; 65536];
-
-    while written < data.len() {
-        match write(pty, &data[written..]) {
-            Ok(n) => written += n,
-            Err(Errno::EAGAIN) => {
-                // PTY buffer full — drain child output to make room
-                match nix_read(pty, &mut read_buf) {
-                    Ok(n) if n > 0 => {
-                        drain_buffer.extend_from_slice(&read_buf[..n]);
-                    }
-                    _ => {
-                        // Nothing available yet, poll briefly
-                        let mut poll_fds = [PollFd::new(
-                            pty.as_fd(),
-                            PollFlags::POLLIN | PollFlags::POLLOUT,
-                        )];
-                        let _ = poll(&mut poll_fds, PollTimeout::from(10u16));
-                    }
-                }
-            }
-            Err(Errno::EINTR) => continue,
-            Err(e) => anyhow::bail!("write to pty failed: {}", e),
-        }
-    }
-    Ok(())
-}
-
-fn nix_read<F: AsFd>(fd: &F, buf: &mut [u8]) -> Result<usize, Errno> {
-    read(fd.as_fd(), buf)
 }
 
 fn split_trailing_marker_prefix<'a>(data: &'a [u8], marker: &[u8]) -> (&'a [u8], &'a [u8]) {


### PR DESCRIPTION
## Summary
- Introduces a `platform/` abstraction module that separates Unix-specific code from core proxy logic
- **Windows implementation** using ConPTY (`CreatePseudoConsole`), Console API, and `WaitForMultipleObjects`
- **Unix implementation** extracted cleanly from existing `proxy.rs` code
- All existing features preserved: bracketed paste, history filter, PTY drain deadlock prevention, Kitty keyboard protocol, auto-lookback, alt-screen handling

## Architecture

```
src/platform/
├── mod.rs       # Shared types (TerminalSize, PlatformSignal, PollResult) + cross-platform wrappers
├── unix.rs      # POSIX PTY, termios, signals, poll()
└── windows.rs   # ConPTY, Console API, WaitForMultipleObjects, SetConsoleCtrlHandler
```

- `proxy.rs` is now fully platform-agnostic, calling only `platform::` functions
- Conditional dependencies: `nix`/`libc` on Unix, `windows` crate on Windows
- CI updated to include `windows-latest` in check and test matrix

## Test plan
- [ ] Verify Unix builds still pass (Linux + macOS)
- [ ] Verify Windows build compiles
- [ ] Test basic proxy functionality on Windows terminal
- [ ] Test lookback mode on Windows
- [ ] Test with Claude Code on Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)