### PR TITLE
Fix busy-loop on EAGAIN that pins a core and wedges the session

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -196,7 +196,7 @@ checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
 
 [[package]]
 name = "claude-chill"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,6 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.4"
+version = "0.1.5"
 edition = "2024"
 authors = ["David Beesley"]

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/davidbeesley/claude-chill/actions/workflows/ci.yml/badge.svg)](https://github.com/davidbeesley/claude-chill/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-![Version](https://img.shields.io/badge/version-0.1.4-blue)
+![Version](https://img.shields.io/badge/version-0.1.5-blue)
 ![Linux](https://img.shields.io/badge/Linux-supported-green)
 ![macOS](https://img.shields.io/badge/macOS-supported-green)
 ![Windows](https://img.shields.io/badge/Windows-unsupported-red)

--- a/crates/claude-chill/src/proxy.rs
+++ b/crates/claude-chill/src/proxy.rs
@@ -94,6 +94,7 @@ impl Drop for TerminalGuard {
 
 const RENDER_DELAY_MS: u64 = 5;
 const SYNC_BLOCK_DELAY_MS: u64 = 50;
+const WRITE_STALL_POLL_MS: u16 = 100;
 
 pub struct Proxy {
     config: ProxyConfig,
@@ -1185,7 +1186,24 @@ fn write_all<F: AsFd>(fd: &F, data: &[u8]) -> Result<()> {
     while written < data.len() {
         match write(fd, &data[written..]) {
             Ok(n) => written += n,
-            Err(Errno::EAGAIN) | Err(Errno::EINTR) => continue,
+            Err(Errno::EINTR) => continue,
+            Err(Errno::EAGAIN) => {
+                // The far end stopped draining. Retrying the write immediately
+                // spins a full core for as long as the stall lasts, so wait for
+                // writability instead.
+                let mut poll_fds = [PollFd::new(fd.as_fd(), PollFlags::POLLOUT)];
+                match poll(&mut poll_fds, PollTimeout::from(WRITE_STALL_POLL_MS)) {
+                    Ok(_) | Err(Errno::EINTR) => {}
+                    Err(e) => anyhow::bail!("poll for writability failed: {}", e),
+                }
+                // run() checks the signal flags only at the top of its loop, so
+                // without this a stalled write leaves the process ignoring SIGTERM
+                // for as long as the far end stays blocked. SIGINT is deliberately
+                // not checked: run() forwards it to the child and keeps going.
+                if SIGTERM_RECEIVED.load(Ordering::SeqCst) {
+                    anyhow::bail!("SIGTERM received while blocked writing to a stalled terminal");
+                }
+            }
             Err(e) => anyhow::bail!("write failed: {}", e),
         }
     }
@@ -1571,5 +1589,39 @@ mod tests {
         let (forward, remainder) = split_trailing_marker_prefix(data, marker);
         assert!(forward.is_empty());
         assert_eq!(remainder, b"\x1b[2");
+    }
+
+    #[test]
+    fn test_write_all_gives_up_when_the_far_end_stalls() {
+        // Once the far end stops draining, write() returns EAGAIN for as long as
+        // the stall lasts. Retrying it immediately pins a core and never returns
+        // to run(), so the proxy also stops forwarding input and stops acting on
+        // SIGTERM - the session is wedged until it is killed with SIGKILL.
+        use nix::unistd::pipe;
+
+        let (reader, writer) = pipe().expect("pipe");
+        set_nonblocking(&writer).expect("set_nonblocking");
+
+        // Fill the pipe buffer. Nothing ever reads `reader`.
+        let filler = vec![b'x'; 1 << 20];
+        while write(&writer, &filler).is_ok() {}
+
+        SIGTERM_RECEIVED.store(true, Ordering::SeqCst);
+        let start = Instant::now();
+        let result = write_all(&writer, b"blocked");
+        let elapsed = start.elapsed();
+        SIGTERM_RECEIVED.store(false, Ordering::SeqCst);
+
+        assert!(
+            result.is_err(),
+            "a write against a stalled reader must give up, not block forever"
+        );
+        assert!(
+            elapsed < Duration::from_secs(2),
+            "a stalled write must wait for writability, not spin (took {:?})",
+            elapsed
+        );
+
+        drop(reader);
     }
 }


### PR DESCRIPTION
Observed on `claude-chill 0.1.4 (2595cf7)`, macOS 15 (arm64), and reproduced on a synthetic harness.

## Symptom

A wrapped session stops responding: no output, keystrokes never reach the child, and the process burns 100% of a core indefinitely. `SIGTERM` does not end it — only `SIGKILL` does. Two instances were caught in the wild: one had burned 99 minutes of CPU in 90 minutes of wall time, the other was still spinning after 23 days (202 hours of CPU).

`sample` of a stuck process, with 2485 of 2525 samples inside the `write` syscall and the rest in the errno path, looping back to the same instruction:

```
2507 claude_chill::proxy::Proxy::run + 1420
  + 2485 write  (in libsystem_kernel.dylib) + 8
  + 16 write + 28
  + ! 9 cerror  (in libsystem_kernel.dylib)
  18 claude_chill::proxy::Proxy::run + 1432
    8 nix::errno::Errno::last
```

## Cause

`write_all` retries `write()` immediately on `EAGAIN`:

```rust
Err(Errno::EAGAIN) | Err(Errno::EINTR) => continue,
```

On a non-blocking fd that retry never blocks, so once the far end of the pty stops draining, the loop spins for as long as the stall lasts.

The second half of the symptom follows from where the loop sits: `run()` checks `SIGWINCH_RECEIVED` / `SIGINT_RECEIVED` / `SIGTERM_RECEIVED` only at the top of its poll loop, and `write_all` never returns to it. So a proxy stuck here also stops forwarding stdin and stops acting on signals — the session is wedged in both directions and survives everything short of `SIGKILL`.

## Relation to #34

#34 fixed the input direction: writes to the pty master now go through `write_to_pty_draining`, which drains child output and polls on `EAGAIN`. `write_all` itself was left unchanged, and it is still what every stdout write goes through (`process_output` flushes, lookback redraw, the alt-screen and exit paths, the bracketed-paste enable/disable), plus one remaining lookback flush to the pty master.

So the output direction can still spin. This patch closes that half.

## Why it needs non-blocking stdio

`set_nonblocking` is applied to the inner pty master (`proxy.rs:259`), but the outer stdio is whatever the parent handed down. Under a terminal whose reader is a Node-based session daemon that is non-blocking, because Node sets `O_NONBLOCK` on the stdio it passes to children. That is what turns a stalled reader into `EAGAIN` instead of a clean block.

With blocking stdio the same write blocks in the kernel at 0% CPU and nothing spins — which is why this does not reproduce under a plain terminal emulator, and why my first three reproduction attempts failed before I set `O_NONBLOCK` on the harness pty.

## Fix

`EAGAIN` now waits on `poll(POLLOUT)` with a 100 ms timeout instead of retrying immediately, and gives up if `SIGTERM` arrived while it was blocked.

`SIGINT` is deliberately **not** checked there: `run()` forwards it to the child and continues, so bailing on it would tear down a session when the user hits Ctrl-C during heavy output.

## Verification

Harness: pty with `O_NONBLOCK` set on the slave, wrapped command printing one line every 50 ms, master never read. Measured after the pty buffer fills.

| | 0.1.4 | patched |
|---|---|---|
| CPU over 8 s once the reader stalls | 7.98 s (100% of a core), state `Rs` | 0.00 s (0%), state `Ss` |
| Ends on `SIGTERM` | no | yes |

The regression test fills a pipe nobody reads and asserts `write_all` returns promptly. Against the old code it **hangs forever** rather than failing — killed at a 90 s timeout — which is the defect stated as a test.

Rebased onto `master` (66cc2ea). All CI jobs were run locally on the rebased branch and pass: version badge, `cargo check --all-targets`, `cargo fmt --all --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test --all-targets` (105 passed), and `expect tests/integration.exp`. `nix build` was not run — no nix on this machine.

## Notes

- Version bumped to 0.1.5 in `Cargo.toml` and the README badge, per `CLAUDE.md`.
- Left undone: `write_all` is a free function with no access to `Proxy::child`, so it cannot forward the signal to the child before returning. A session terminated this way still depends on the pty master closing to hang the child up. Happy to restructure it into a method if you would rather it forwarded first.
